### PR TITLE
Refactored employee form to use current user while registering location

### DIFF
--- a/src/components/employees/EmployeeForm.js
+++ b/src/components/employees/EmployeeForm.js
@@ -1,96 +1,75 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useState } from "react";
 import EmployeeRepository from "../../repositories/EmployeeRepository";
 import LocationRepository from "../../repositories/LocationRepository";
-import { useHistory } from "react-router-dom/cjs/react-router-dom.min"
-import Employee from "./Employee";
-import "./EmployeeForm.css"
-
+import { useHistory } from "react-router-dom/cjs/react-router-dom.min";
+import useSimpleAuth from "../../hooks/ui/useSimpleAuth";
+import "./EmployeeForm.css";
 
 export default (props) => {
-    const [employee, updateEmployee] = useState({})
-    const [locations, defineLocations] = useState([])
-    const [emps, setEmployees] = useState([])
-    
-    const history = useHistory()
+  const [employee, updateEmployee] = useState({});
+  const [empObject, updateEmpObject] = useState({});
+  const [locations, defineLocations] = useState([]);
 
-    useEffect(
-        () => {
-            EmployeeRepository.getAll().then(setEmployees)
-        }, []
-    )
-    useEffect(
-        () => {
-            LocationRepository.getAll().then(defineLocations)
-        }, []
-    )
-    
-    const constructNewEmployee = () => {
-        if (employee.location === 0) {
-            window.alert("Please select a location")
-        } else {
-            EmployeeRepository.assignEmployee({
-                userId: parseInt(employee.employee),
-                locationId: parseInt(employee.location)
-            })
-            .then(() => history.push("/employees"))
-        }
+  const history = useHistory();
+
+  useEffect(() => {
+    LocationRepository.getAll().then(defineLocations);
+  }, []);
+
+  useEffect(() => {
+    updateEmpObject(useSimpleAuth().getCurrentUser());
+  }, []);
+
+  const constructNewEmployee = () => {
+    if (employee.location === 0) {
+      window.alert("Please select a location");
+    } else {
+      EmployeeRepository.assignEmployee({
+        userId: parseInt(empObject.id),
+        locationId: parseInt(employee.location),
+      }).then(() => history.push("/employees"));
     }
-    
+  };
 
-    const handleUserInput = (event) => {
-        const copy = {...employee}
-        copy[event.target.name] = event.target.value
-        updateEmployee(copy)
-    }
+  const handleUserInput = (event) => {
+    const copy = { ...employee };
+    copy[event.target.name] = event.target.value;
+    updateEmployee(copy);
+  };
 
-   
+  return (
+    <>
+      <form className="employeeForm">
+        <h2 className="employeeForm__title">Welcome {empObject.name}</h2>
 
-
-
-    return (
-        <>
-            <form className="employeeForm">
-                <h2 className="employeeForm__title">New Employee</h2>
-                <div className="form-group">
-                    <label htmlFor="employeeName">Employee name</label>
-                    <select onChange={handleUserInput}
-                     defaultValue=""
-                     name="employee"
-                     className="form-control"
-                     >
-                         <option value="0">Select your name</option>
-
-                         {emps.map(e => (
-                             <option key={e.id} value={e.id}>
-                                 {e.name}
-                             </option>
-                         ))}
-                     </select>
-                </div>
-                <div className="form-group">
-                    <label htmlFor="location">Assign to location</label>
-                    <select onChange={handleUserInput}
-                        defaultValue=""
-                        name="location"
-                        className="form-control"
-                    >
-                        <option value="0">Select a location</option>
-                        {locations.map(l => (
-                            <option key={l.id} value={l.id}>
-                                {l.name}
-                            </option>
-                        ))}
-                    </select>
-                </div>
-                <button type="submit"
-                    onClick={
-                        evt => {
-                            evt.preventDefault()
-                            constructNewEmployee()
-                        }
-                    }
-                    className="btn btn-primary"> Save Employee </button>
-            </form>
-        </>
-    )
-}
+        <div className="form-group">
+          <label htmlFor="location">Please choose your location</label>
+          <select
+            onChange={handleUserInput}
+            defaultValue=""
+            name="location"
+            className="form-control"
+          >
+            <option value="0">Select a location</option>
+            {locations.map((l) => (
+              <option key={l.id} value={l.id}>
+                {l.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          type="submit"
+          onClick={(evt) => {
+            evt.preventDefault();
+            constructNewEmployee();
+          }}
+          className="btn btn-primary"
+        >
+          {" "}
+          Save Employee{" "}
+        </button>
+      </form>
+    </>
+  );
+};


### PR DESCRIPTION
#### Changes Made
1. Modified file `employeeForm.js` to include `getCurrentUser()` from `useSimpleAuth` and use the current user's login in information to select a location, rather than a drop down.
​
#### Steps to Review
1. Checkout this branch locally.
    ```
    git fetch --all
    git checkout sh-employeeRegisterUpdate
2. Open a new Terminal tab (⌘T) and navigate to the server directory.
3. Test app functionality.
    > When a new user is created, after they check that they are an employee, they will be routed to a location selection form which will match the location selected and their userId and post that information to employeeLocations. User no longer has to select their own name in a drop down. This also allows for the ability to add a second location in the future.
4. View code file.
    > Confirm file modifications are present as indicated above.
    > Confirm no unused code or extraneous comments exist.